### PR TITLE
Throw InvalidTableIndex when decoding out-of-range table indices.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,10 +6,14 @@ dev
 
 **API Changes (Backward Incompatible)**
 
+- Added new ``InvalidTableIndex`` exception, a subclass of
+  ``HPACKDecodingError``.
 - Instead of throwing ``IndexError`` when encountering invalid encoded integers
   HPACK now throws ``HPACKDecodingError``.
 - Instead of throwing ``UnicodeDecodeError`` when encountering headers that are
   not UTF-8 encoded, HPACK now throws ``HPACKDecodingError``.
+- Instead of throwing ``IndexError`` when encountering invalid table offsets,
+  HPACK now throws ``InvalidTableIndex``.
 
 2.0.1 (2015-11-09)
 ------------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -12,3 +12,5 @@ This document provides the HPACK API.
 .. autoclass:: hpack.HPACKError
 
 .. autoclass:: hpack.HPACKDecodingError
+
+.. autoclass:: hpack.InvalidTableIndex

--- a/hpack/exceptions.py
+++ b/hpack/exceptions.py
@@ -19,3 +19,10 @@ class HPACKDecodingError(HPACKError):
     An error has been encountered while performing HPACK decoding.
     """
     pass
+
+
+class InvalidTableIndex(HPACKDecodingError):
+    """
+    An invalid table index was received.
+    """
+    pass

--- a/hpack/table.py
+++ b/hpack/table.py
@@ -1,6 +1,8 @@
 from collections import deque
 import logging
 
+from .exceptions import InvalidTableIndex
+
 log = logging.getLogger(__name__)
 
 
@@ -117,14 +119,12 @@ class HeaderTable(object):
         the dynamic table depending on the value of index.
         """
         index -= 1
-        if index < 0:
-            return None # TODO throw HPACKException here
-        if index < len(HeaderTable.STATIC_TABLE):
+        if 0 <= index < len(HeaderTable.STATIC_TABLE):
             return HeaderTable.STATIC_TABLE[index]
         index -= len(HeaderTable.STATIC_TABLE)
-        if index < len(self.dynamic_entries):
+        if 0 <= index < len(self.dynamic_entries):
             return self.dynamic_entries[index]
-        return None # TODO throw HPACKException here
+        raise InvalidTableIndex("Invalid table index %d" % index)
 
     def __repr__(self):
         return "HeaderTable(%d, %s, %r)" % (

--- a/test/test_hpack.py
+++ b/test/test_hpack.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from hpack.hpack import Encoder, Decoder, encode_integer, decode_integer
 from hpack.huffman import HuffmanDecoder
-from hpack.exceptions import HPACKDecodingError
+from hpack.exceptions import HPACKDecodingError, InvalidTableIndex
 import os
 import pytest
 
@@ -511,6 +511,22 @@ class TestHPACKDecoder(object):
         data = b'\x82\x86\x84\x01\x10www.\x07\xaa\xd7\x95\xd7\xa8\xd7\x94.com'
 
         with pytest.raises(HPACKDecodingError):
+            d.decode(data)
+
+    def test_invalid_indexed_literal(self):
+        d = Decoder()
+
+        # Refer to an index that is too large.
+        data = b'\x82\x86\x84\x7f\x0a\x0fwww.example.com'
+        with pytest.raises(InvalidTableIndex):
+            d.decode(data)
+
+    def test_invalid_indexed_header(self):
+        d = Decoder()
+
+        # Refer to an indexed header that is too large.
+        data = b'\xBE\x86\x84\x01\x0fwww.example.com'
+        with pytest.raises(InvalidTableIndex):
             d.decode(data)
 
 

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -1,4 +1,5 @@
 from hpack.table import HeaderTable, table_entry_size
+from hpack.exceptions import InvalidTableIndex
 import pytest
 import sys
 _ver = sys.version_info
@@ -31,15 +32,15 @@ class TestHeaderTable(object):
 
     def test_get_by_index_zero_index(self):
         tbl = HeaderTable()
-        res = tbl.get_by_index(0)
-        assert res is None # TODO HPACKException will be raised instead
+        with pytest.raises(InvalidTableIndex):
+            res = tbl.get_by_index(0)
 
     def test_get_by_index_out_of_range(self):
         tbl = HeaderTable()
         off = len(HeaderTable.STATIC_TABLE)
         tbl.add(b'TestName', b'TestValue')
-        res = tbl.get_by_index(off+2)
-        assert res is None # TODO HPACKException will be raised instead
+        with pytest.raises(InvalidTableIndex):
+            res = tbl.get_by_index(off+2)
 
     def test_repr(self):
         tbl = HeaderTable()


### PR DESCRIPTION
Resolves #25.