### PR TITLE
Add Jython build for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy
+envlist = py27, py33, py34, py35, pypy, jython
 
 [testenv]
 deps= -r{toxinidir}/test_requirements.txt
@@ -8,3 +8,7 @@ commands= py.test -n 4 --cov hpack {toxinidir}/test/
 [testenv:pypy]
 # temporarily disable coverage testing on PyPy due to performance problems
 commands= py.test -n 4 hpack {toxinidir}/test/
+
+[testenv:jython]
+deps = pytest==2.9.0
+commands= py.test hpack {toxinidir}/test/


### PR DESCRIPTION
Unfortunately Jython still has some bugs and for now it fails on requirements file parsing, but explicit deps work just fine.
I'm still figuring out the best way to set in on Travis.

P.S. This build works on tox-2.3.1 and virtualenv 15, older versions have some issues with proper shebang 
