### PR TITLE
Make sure we bring special headers to the start when working with dictionaries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .coverage
 .tox/
 .cache
+.hypothesis

--- a/hpack/hpack.py
+++ b/hpack/hpack.py
@@ -21,6 +21,11 @@ INDEX_NONE = b'\x00'
 INDEX_NEVER = b'\x10'
 INDEX_INCREMENTAL = b'\x40'
 
+try:  # pragma: no cover
+    basestring = basestring
+except NameError:  # pragma: no cover
+    basestring = (str, bytes)
+
 
 def encode_integer(integer, prefix_bits):
     """
@@ -86,7 +91,7 @@ def _to_bytes(string):
     """
     Convert string to bytes.
     """
-    if not isinstance(string, (str, bytes)):  # pragma: no cover
+    if not isinstance(string, (basestring)):  # pragma: no cover
         string = str(string)
 
     return string if isinstance(string, bytes) else string.encode('utf-8')
@@ -149,7 +154,8 @@ class Encoder(object):
         header_block = []
 
         # Turn the headers into a list of tuples if possible. This is the
-        # natural way to interact with them in HPACK.
+        # natural way to interact with them in HPACK. Because dictionaries are
+        # un-ordered, we need to make sure we grab the "special" headers first.
         if isinstance(headers, dict):
             headers = headers.items()
 

--- a/hpack/hpack.py
+++ b/hpack/hpack.py
@@ -172,7 +172,7 @@ class Encoder(object):
         # natural way to interact with them in HPACK. Because dictionaries are
         # un-ordered, we need to make sure we grab the "special" headers first.
         if isinstance(headers, dict):
-            headers = headers.items()
+            headers = _dict_to_iterable(headers)
 
         # Before we begin, if the header table size has been changed we need
         # to signal all changes since last emission appropriately.

--- a/hpack/hpack.py
+++ b/hpack/hpack.py
@@ -87,6 +87,21 @@ def decode_integer(data, prefix_bits):
     return number, index + 1
 
 
+def _dict_to_iterable(header_dict):
+    """
+    This converts a dictionary to an iterable of two-tuples. This is a
+    HPACK-specific function becuase it pulls "special-headers" out first and
+    then emits them.
+    """
+    assert isinstance(header_dict, dict)
+    keys = sorted(
+        header_dict.keys(),
+        key=lambda k: not _to_bytes(k).startswith(b':')
+    )
+    for key in keys:
+        yield key, header_dict[key]
+
+
 def _to_bytes(string):
     """
     Convert string to bytes.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest==2.9.0
 pytest-xdist==1.14
 pytest-cov==2.2.1
+hypothesis==3.1.0


### PR DESCRIPTION
When a user passes HPACK a dictionary, we should make sure we don't encode an invalid header block by bringing the special headers to the front of the iterable. This change does that.