### PR TITLE
Cache table size, don't dynamically recompute.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ dev (XXXX)
 **Bugfixes**
 
 - Improve Huffman decoding speed by 4x using an approach borrowed from nghttp2.
+- Improve HPACK decoding speed by 10% by caching header table sizes.
 
 2.1.1 (2016-03-16)
 ------------------

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -133,7 +133,7 @@ class TestHeaderTable(object):
         tbl = HeaderTable()
         for i in range(3):
             tbl.add(b'TestValue', b'TestName')
-        res = tbl._size()
+        res = tbl._current_size
         assert res == 147
 
     def test_shrink_maxsize_is_zero(self):


### PR DESCRIPTION
This buys us about a 10% speedup on HPACK decoding times.