### PR TITLE
Add tuples that flag indexability of header fields.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,15 @@ Release History
 dev (XXXX)
 ----------
 
+**API Changes (Backward Compatible)**
+
+- Added ``HeaderTuple`` and ``NeverIndexedHeaderTuple`` classes that signal
+  whether a given header field may ever be indexed in HTTP/2 header
+  compression.
+- Changed ``Decoder.decode()`` to return the newly added ``HeaderTuple`` class
+  and subclass. These objects behave like two-tuples, so this change does not
+  break working code.
+
 **Bugfixes**
 
 - Improve Huffman decoding speed by 4x using an approach borrowed from nghttp2.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,12 @@ This document provides the HPACK API.
 .. autoclass:: hpack.Decoder
    :members: header_table_size, decode
 
+.. autoclass:: hpack.HeaderTuple
+   :members: indexable
+
+.. autoclass:: hpack.NeverIndexedHeaderTuple
+   :members: indexable
+
 .. autoclass:: hpack.HPACKError
 
 .. autoclass:: hpack.HPACKDecodingError

--- a/hpack/__init__.py
+++ b/hpack/__init__.py
@@ -6,11 +6,12 @@ hpack
 HTTP/2 header encoding for Python.
 """
 from .hpack import Encoder, Decoder
+from .struct import HeaderTuple, NeverIndexedHeaderTuple
 from .exceptions import HPACKError, HPACKDecodingError, InvalidTableIndex
 
 __all__ = [
     'Encoder', 'Decoder', 'HPACKError', 'HPACKDecodingError',
-    'InvalidTableIndex'
+    'InvalidTableIndex', 'HeaderTuple', 'NeverIndexedHeaderTuple'
 ]
 
 __version__ = '2.1.1'

--- a/hpack/hpack.py
+++ b/hpack/hpack.py
@@ -33,11 +33,12 @@ def _unicode_if_needed(header, raw):
     Provides a header as a unicode string if raw is False, otherwise returns
     it as a bytestring.
     """
-    return tuple(
-        to_bytes(i) if raw
-        else to_bytes(i).decode('utf-8')
-        for i in header
-    )
+    name = to_bytes(header[0])
+    value = to_bytes(header[1])
+    if not raw:
+        name = name.decode('utf-8')
+        value = value.decode('utf-8')
+    return header.__class__(name, value)
 
 
 def encode_integer(integer, prefix_bits):

--- a/hpack/struct.py
+++ b/hpack/struct.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+hpack/struct
+~~~~~~~~~~~~
+
+Contains structures for representing header fields with associated metadata.
+"""
+
+
+class HeaderTuple(tuple):
+    """
+    A data structure that stores a single header field.
+
+    HTTP headers can be thought of as tuples of ``(field name, field value)``.
+    A single header block is a sequence of such tuples.
+
+    In HTTP/2, however, certain bits of additional information are required for
+    compressing these headers: in particular, whether the header field can be
+    safely added to the HPACK compression context.
+
+    This class stores a header that can be added to the compression context. In
+    all other ways it behaves exactly like a tuple.
+    """
+    __slots__ = ()
+
+    indexable = True
+
+    def __new__(_cls, *args):
+        return tuple.__new__(_cls, args)
+
+
+class NeverIndexedHeaderTuple(HeaderTuple):
+    """
+    A data structure that stores a single header field that cannot be added to
+    a HTTP/2 header compression context.
+    """
+    __slots__ = ()
+
+    indexable = False

--- a/test/test_hpack.py
+++ b/test/test_hpack.py
@@ -48,7 +48,43 @@ class TestHPACKEncoder(object):
         header_set = [
             (':method', 'GET', True),
             (':path', '/jimiscool/', True),
-            ('customkey', 'sensitiveinfo', True)
+            ('customkey', 'sensitiveinfo', True),
+        ]
+        assert e.encode(header_set, huffman=True) == result
+
+    def test_non_sensitive_headers_with_header_tuples(self):
+        """
+        A header field stored in a HeaderTuple emits a representation that
+        allows indexing.
+        """
+        e = Encoder()
+        result = (b'\x82\x44\x88\x63\xa1\xa9' +
+                  b'\x32\x08\x73\xd0\xc7\x40' +
+                  b'\x87\x25\xa8\x49\xe9\xea' +
+                  b'\x5f\x5f\x89\x41\x6a\x41' +
+                  b'\x92\x6e\xe5\x35\x52\x9f')
+        header_set = [
+            HeaderTuple(':method', 'GET'),
+            HeaderTuple(':path', '/jimiscool/'),
+            HeaderTuple('customkey', 'sensitiveinfo'),
+        ]
+        assert e.encode(header_set, huffman=True) == result
+
+    def test_sensitive_headers_with_header_tuples(self):
+        """
+        A header field stored in a NeverIndexedHeaderTuple emits a
+        representation that forbids indexing.
+        """
+        e = Encoder()
+        result = (b'\x82\x14\x88\x63\xa1\xa9' +
+                  b'\x32\x08\x73\xd0\xc7\x10' +
+                  b'\x87\x25\xa8\x49\xe9\xea' +
+                  b'\x5f\x5f\x89\x41\x6a\x41' +
+                  b'\x92\x6e\xe5\x35\x52\x9f')
+        header_set = [
+            NeverIndexedHeaderTuple(':method', 'GET'),
+            NeverIndexedHeaderTuple(':path', '/jimiscool/'),
+            NeverIndexedHeaderTuple('customkey', 'sensitiveinfo'),
         ]
         assert e.encode(header_set, huffman=True) == result
 

--- a/test/test_hpack_integration.py
+++ b/test/test_hpack_integration.py
@@ -5,6 +5,7 @@ long time to run, so they're outside the main test suite, but they need to be
 run before every change to HPACK.
 """
 from hpack.hpack import Decoder, Encoder
+from hpack.struct import HeaderTuple
 from binascii import unhexlify
 from pytest import skip
 
@@ -32,6 +33,9 @@ class TestHPACKDecoderIntegration(object):
             ]
             correct_headers = correct_headers
             assert correct_headers == decoded_headers
+            assert all(
+                isinstance(header, HeaderTuple) for header in decoded_headers
+            )
 
     def test_can_encode_a_story_no_huffman(self, raw_story):
         d = Decoder()
@@ -49,6 +53,9 @@ class TestHPACKDecoderIntegration(object):
             decoded_headers = d.decode(encoded)
 
             assert input_headers == decoded_headers
+            assert all(
+                isinstance(header, HeaderTuple) for header in decoded_headers
+            )
 
     def test_can_encode_a_story_with_huffman(self, raw_story):
         d = Decoder()

--- a/test/test_struct.py
+++ b/test/test_struct.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""
+test_struct
+~~~~~~~~~~~
+
+Tests for the Header tuples.
+"""
+import pytest
+
+from hpack.struct import HeaderTuple, NeverIndexedHeaderTuple
+
+
+class TestHeaderTuple(object):
+    def test_is_tuple(self):
+        """
+        HeaderTuple objects are tuples.
+        """
+        h = HeaderTuple('name', 'value')
+        assert isinstance(h, tuple)
+
+    def test_unpacks_properly(self):
+        """
+        HeaderTuple objects unpack like tuples.
+        """
+        h = HeaderTuple('name', 'value')
+        k, v = h
+
+        assert k == 'name'
+        assert v == 'value'
+
+    def test_header_tuples_are_indexable(self):
+        """
+        HeaderTuple objects can be indexed.
+        """
+        h = HeaderTuple('name', 'value')
+        assert h.indexable
+
+    def test_never_indexed_tuples_are_not_indexable(self):
+        """
+        NeverIndexedHeaderTuple objects cannot be indexed.
+        """
+        h = NeverIndexedHeaderTuple('name', 'value')
+        assert not h.indexable
+
+    @pytest.mark.parametrize('cls', (HeaderTuple, NeverIndexedHeaderTuple))
+    def test_equal_to_tuples(self, cls):
+        """
+        HeaderTuples and NeverIndexedHeaderTuples are equal to equivalent
+        tuples.
+        """
+        t1 = ('name', 'value')
+        t2 = cls('name', 'value')
+
+        assert t1 == t2
+        assert t1 is not t2
+
+    @pytest.mark.parametrize('cls', (HeaderTuple, NeverIndexedHeaderTuple))
+    def test_equal_to_self(self, cls):
+        """
+        HeaderTuples and NeverIndexedHeaderTuples are always equal when
+        compared to the same class.
+        """
+        t1 = cls('name', 'value')
+        t2 = cls('name', 'value')
+
+        assert t1 == t2
+        assert t1 is not t2
+
+    def test_equal_for_different_indexes(self):
+        """
+        HeaderTuples compare equal to equivalent NeverIndexedHeaderTuples.
+        """
+        t1 = HeaderTuple('name', 'value')
+        t2 = NeverIndexedHeaderTuple('name', 'value')
+
+        assert t1 == t2
+        assert t1 is not t2


### PR DESCRIPTION
This is needed for python-hyper/hyper-h2#194. It changes HPACK to accept and emit special tuples that can be used to signal the indexability of a header field.