### PR TITLE
CVE-2016-6581

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,25 @@
 Release History
 ===============
 
+2.3.0 (2016-08-04)
+------------------
+
+**Security Fixes**
+
+- CVE-2016-6581: HPACK Bomb. This release now enforces a maximum value of the
+  decompressed size of the header list. This is to avoid the so-called "HPACK
+  Bomb" vulnerability, which is caused when a malicious peer sends a compressed
+  HPACK body that decompresses to a gigantic header list size.
+
+  This also adds a ``OversizedHeaderListError``, which is thrown by the
+  ``decode`` method if the maximum header list size is being violated. This
+  places the HPACK decoder into a broken state: it must not be used after this
+  exception is thrown.
+
+  This also adds a ``max_header_list_size`` to the ``Decoder`` object. This
+  controls the maximum allowable decompressed size of the header list. By
+  default this is set to 64kB.
+
 2.2.0 (2016-04-20)
 ------------------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -20,3 +20,5 @@ This document provides the HPACK API.
 .. autoclass:: hpack.HPACKDecodingError
 
 .. autoclass:: hpack.InvalidTableIndex
+
+.. autoclass:: hpack.OversizedHeaderListError

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ Contents
 
    installation
    api
+   security/index
 
 
 .. _HPACK: https://tools.ietf.org/html/rfc7541

--- a/docs/source/security/CVE-2016-6581.rst
+++ b/docs/source/security/CVE-2016-6581.rst
@@ -1,0 +1,73 @@
+:orphan:
+
+HPACK Bomb
+==========
+
+Hyper Project security advisory, August 4th 2016.
+
+Vulnerability
+-------------
+
+A HTTP/2 implementation built using the priority library could be targetted for
+a denial of service attack based on HPACK, specifically a so-called "HPACK
+Bomb" attack.
+
+This attack occurs when an attacker inserts a header field that is exactly the
+size of the HPACK dynamic header table into the dynamic header table. The
+attacker can then send a header block that is simply repeated requests to
+expand that field in the dynamic table. This can lead to a gigantic compression
+ratio of 4,096 or better, meaning that 16kB of data can decompress to 64MB of
+data on the target machine.
+
+It only takes a few such header blocks before the attacker has forced the
+target to allocate gigabytes of memory, which will take the process down. This
+requires relatively few resources on the part of the attacker.
+
+While we are not aware of any attacker actively exploiting this vulnerability,
+it has been public disclosed in `this report`_, and so users should assume that
+they are likely to be targetted by such an attack.
+
+Info
+----
+
+This issue has been given the name CVE-2016-6581.
+
+Affected Versions
+-----------------
+
+This issue affects all versions of the HPACK library prior to 2.3.0.
+
+The Solution
+------------
+
+In version 2.3.0, the HPACK library limits the maximum decompressed size of the
+header block. It does so by essentially adding support for the HTTP/2 setting
+``SETTINGS_MAX_HEADER_LIST_SIZE``. This value defaults to 64kB, but is
+user-configurable.
+
+If it is necessary to backport a patch, the patch can be found in
+`this GitHub pull request`_.
+
+Recommendations
+---------------
+
+We suggest you take the following actions immediately, in order of preference:
+
+1. Update HPACK to 2.3.0 immediately.
+2. Backport the patch made available on GitHub.
+3. Substantially decrease the maximum size of the compressed header block your
+   application will accept, or alternatively ensure that each decompressed
+   header block is freed before your application processes the next one.
+
+Timeline
+--------
+
+This class of vulnerability was publicly reported in `this report`_ on the
+3rd of August. We requested a CVE ID from Mitre the same day.
+
+HPACK 2.3.0 was released on the 4th of August, at the same time as the
+publication of this advisory.
+
+
+.. _this report: http://www.imperva.com/docs/Imperva_HII_HTTP2.pdf
+.. _this GitHub pull request: https://github.com/python-hyper/hpack/pull/56

--- a/docs/source/security/index.rst
+++ b/docs/source/security/index.rst
@@ -1,0 +1,18 @@
+Vulnerability Notifications
+===========================
+
+This section of the page contains all known vulnerabilities in the HPACK
+library. These vulnerabilities have all been reported to us via our
+`vulnerability disclosure policy`_.
+
+Known Vulnerabilities
+---------------------
+
++----+---------------------------+----------------+---------------+--------------+---------------+
+| \# |       Vulnerability       | Date Announced | First Version | Last Version |      CVE      |
++====+===========================+================+===============+==============+===============+
+| 1  | :doc:`HPACK Bomb          | 2016-08-04     | 1.0.0         | 2.2.0        | CVE-2016-6581 |
+|    | <CVE-2016-6581>`          |                |               |              |               |
++----+---------------------------+----------------+---------------+--------------+---------------+
+
+.. _vulnerability disclosure policy: http://python-hyper.org/en/latest/security.html#vulnerability-disclosure

--- a/hpack/__init__.py
+++ b/hpack/__init__.py
@@ -7,11 +7,14 @@ HTTP/2 header encoding for Python.
 """
 from .hpack import Encoder, Decoder
 from .struct import HeaderTuple, NeverIndexedHeaderTuple
-from .exceptions import HPACKError, HPACKDecodingError, InvalidTableIndex
+from .exceptions import (
+    HPACKError, HPACKDecodingError, InvalidTableIndex, OversizedHeaderListError
+)
 
 __all__ = [
     'Encoder', 'Decoder', 'HPACKError', 'HPACKDecodingError',
-    'InvalidTableIndex', 'HeaderTuple', 'NeverIndexedHeaderTuple'
+    'InvalidTableIndex', 'HeaderTuple', 'NeverIndexedHeaderTuple',
+    'OversizedHeaderListError'
 ]
 
 __version__ = '2.2.0'

--- a/hpack/exceptions.py
+++ b/hpack/exceptions.py
@@ -32,5 +32,7 @@ class OversizedHeaderListError(HPACKDecodingError):
     """
     A header list that was larger than we allow has been received. This may be
     a DoS attack.
+
+    .. versionadded:: 2.3.0
     """
     pass

--- a/hpack/exceptions.py
+++ b/hpack/exceptions.py
@@ -26,3 +26,11 @@ class InvalidTableIndex(HPACKDecodingError):
     An invalid table index was received.
     """
     pass
+
+
+class OversizedHeaderListError(HPACKDecodingError):
+    """
+    A header list that was larger than we allow has been received. This may be
+    a DoS attack.
+    """
+    pass

--- a/test/test_hpack.py
+++ b/test/test_hpack.py
@@ -3,7 +3,9 @@ from hpack.hpack import (
     Encoder, Decoder, encode_integer, decode_integer, _dict_to_iterable,
     _to_bytes
 )
-from hpack.exceptions import HPACKDecodingError, InvalidTableIndex
+from hpack.exceptions import (
+    HPACKDecodingError, InvalidTableIndex, OversizedHeaderListError
+)
 from hpack.struct import HeaderTuple, NeverIndexedHeaderTuple
 import itertools
 import os
@@ -627,6 +629,17 @@ class TestHPACKDecoder(object):
 
         header = headers[0]
         assert isinstance(header, NeverIndexedHeaderTuple)
+
+    def test_max_header_list_size(self):
+        """
+        If the header block is larger than the max_header_list_size, the HPACK
+        decoder throws an OversizedHeaderListError.
+        """
+        d = Decoder(max_header_list_size=44)
+        data = b'\x14\x0c/sample/path'
+
+        with pytest.raises(OversizedHeaderListError):
+            d.decode(data)
 
 
 class TestIntegerEncoding(object):


### PR DESCRIPTION
A HTTP/2 implementation built using the priority library could be targetted for a denial of service attack based on HPACK, specifically a so-called "HPACK Bomb" attack.

This attack occurs when an attacker inserts a header field that is exactly the size of the HPACK dynamic header table into the dynamic header table. The attacker can then send a header block that is simply repeated requests to expand that field in the dynamic table. This can lead to a gigantic compression ratio of 4,096 or better, meaning that 16kB of data can decompress to 64MB of data on the target machine.

It only takes a few such header blocks before the attacker has forced the target to allocate gigabytes of memory, which will take the process down. This requires relatively few resources on the part of the attacker.

While we are not aware of any attacker actively exploiting this vulnerability, it has been public disclosed in [this report](http://www.imperva.com/docs/Imperva_HII_HTTP2.pdf), and so users should assume that they are likely to be targetted by such an attack.