### PR TITLE
InvalidTableIndex error doesn't match input index

### DIFF
--- a/hpack/table.py
+++ b/hpack/table.py
@@ -121,13 +121,14 @@ class HeaderTable(object):
         The entry will either be from the static table or
         the dynamic table depending on the value of index.
         """
+        original_index = index
         index -= 1
         if 0 <= index < len(HeaderTable.STATIC_TABLE):
             return HeaderTable.STATIC_TABLE[index]
         index -= len(HeaderTable.STATIC_TABLE)
         if 0 <= index < len(self.dynamic_entries):
             return self.dynamic_entries[index]
-        raise InvalidTableIndex("Invalid table index %d" % index)
+        raise InvalidTableIndex("Invalid table index %d" % original_index)
 
     def __repr__(self):
         return "HeaderTable(%d, %s, %r)" % (


### PR DESCRIPTION
The index value is modified in-place, leading to a misleading error message. For example, [here](https://github.com/python-hyper/hpack/blob/master/test/test_table.py#L36), the message reads `Invalid table index -63`, rather than `Invalid table index 0`.