### PR TITLE
Allow multiple header table size updates.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ dev
 
 - Up to 25% performance improvement decoding HPACK-packed integers, depending
   on the platform.
+- HPACK now tolerates receiving multiple header table size changes in sequence,
+  rather than only one.
 - Other miscellaneous performance improvements.
 
 2.3.0 (2016-08-04)

--- a/hpack/hpack.py
+++ b/hpack/hpack.py
@@ -468,7 +468,9 @@ class Decoder(object):
                 )
             elif encoding_update:
                 # It's an update to the encoding context.
-                consumed = self._update_encoding_context(data_mem)
+                consumed = self._update_encoding_context(
+                    data_mem[current_index:]
+                )
                 header = None
             else:
                 # It's a literal header that does not affect the header table.

--- a/test/test_hpack.py
+++ b/test/test_hpack.py
@@ -637,6 +637,22 @@ class TestHPACKDecoder(object):
         with pytest.raises(OversizedHeaderListError):
             d.decode(data)
 
+    def test_can_decode_multiple_header_table_size_changes(self):
+        """
+        If multiple header table size changes are sent in at once, they are
+        successfully decoded.
+        """
+        d = Decoder()
+        data = b'?a?\xe1\x1f\x82\x87\x84A\x8a\x08\x9d\\\x0b\x81p\xdcy\xa6\x99'
+        expect = [
+            (':method', 'GET'),
+            (':scheme', 'https'),
+            (':path', '/'),
+            (':authority', '127.0.0.1:8443')
+        ]
+
+        assert d.decode(data) == expect
+
 
 class TestDictToIterable(object):
     """


### PR DESCRIPTION
Resolves #95.

This one was just a simple programming error.