### PR TITLE
Provide support for enforcing the maximum table size in the decoder.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,16 @@ dev
 - Removed nghttp2 support. This support had rotted and was essentially
   non-functional, so it has now been removed until someone has time to re-add
   the support in a functional form.
+- Attempts by the encoder to exceed the maximum allowed header table size via
+  dynamic table size updates (or the absence thereof) are now forbidden.
+
+**API Changes (Backward Compatible)**
+
+- Added a new ``InvalidTableSizeError`` thrown when the encoder does not
+  respect the maximum table size set by the user.
+- Added a ``Decoder.max_allowed_table_size`` field that sets the maximum
+  allowed size of the decoder header table. See the documentation for an
+  indication of how this should be used.
 
 **Bugfixes**
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -22,3 +22,5 @@ This document provides the HPACK API.
 .. autoclass:: hpack.InvalidTableIndex
 
 .. autoclass:: hpack.OversizedHeaderListError
+
+.. autoclass:: hpack.InvalidTableSizeError

--- a/hpack/exceptions.py
+++ b/hpack/exceptions.py
@@ -36,3 +36,14 @@ class OversizedHeaderListError(HPACKDecodingError):
     .. versionadded:: 2.3.0
     """
     pass
+
+
+class InvalidTableSizeError(HPACKDecodingError):
+    """
+    An attempt was made to change the decoder table size to a value larger than
+    allowed, or the list was shrunk and the remote peer didn't shrink their
+    table size.
+
+    .. versionadded:: 3.0.0
+    """
+    pass

--- a/hpack/hpack.py
+++ b/hpack/hpack.py
@@ -409,6 +409,15 @@ class Decoder(object):
         #: .. versionadded:: 2.3.0
         self.max_header_list_size = max_header_list_size
 
+        #: Maximum allowed header table size.
+        #:
+        #: A HTTP/2 implementation should set this to the most recent value of
+        #: SETTINGS_HEADER_TABLE_SIZE that it sent *and has received an ACK
+        #: for*. Once this setting is set, the actual header table size will be
+        #: checked at the end of each decoding run and whenever it is changed,
+        #: to confirm that it fits in this size.
+        self.max_allowed_table_size = self.header_table.maxsize
+
     @property
     def header_table_size(self):
         """


### PR DESCRIPTION
This is needed for python-hyper/hyper-h2#511. Essentially it allows us to ensure that the remote peer doesn't increase the header table size via a dynamic table size update beyond the value we have set for SETTINGS_HEADER_TABLE_SIZE.

Once this lands I'll probably push out HPACK 3.0.