### PR TITLE
Forbid table size updates anywhere but first in a header block.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,8 @@ dev
   on the platform.
 - HPACK now tolerates receiving multiple header table size changes in sequence,
   rather than only one.
+- HPACK now forbids header table size changes anywhere but first in a header
+  block, as required by RFC 7541 § 4.2.
 - Other miscellaneous performance improvements.
 
 2.3.0 (2016-08-04)

--- a/hpack/hpack.py
+++ b/hpack/hpack.py
@@ -478,7 +478,12 @@ class Decoder(object):
                     data_mem[current_index:]
                 )
             elif encoding_update:
-                # It's an update to the encoding context.
+                # It's an update to the encoding context. These are forbidden
+                # in a header block after any actual header.
+                if headers:
+                    raise HPACKDecodingError(
+                        "Table size update not at the start of the block"
+                    )
                 consumed = self._update_encoding_context(
                     data_mem[current_index:]
                 )

--- a/hpack/hpack.py
+++ b/hpack/hpack.py
@@ -509,15 +509,22 @@ class Decoder(object):
         # Confirm that the table size is lower than the maximum. We do this
         # here to ensure that we catch when the max has been *shrunk* and the
         # remote peer hasn't actually done that.
-        if self.header_table_size > self.max_allowed_table_size:
-            raise InvalidTableSizeError(
-                "Encoder did not shrink table size to within the max"
-            )
+        self._assert_valid_table_size()
 
         try:
             return [_unicode_if_needed(h, raw) for h in headers]
         except UnicodeDecodeError:
             raise HPACKDecodingError("Unable to decode headers as UTF-8.")
+
+    def _assert_valid_table_size(self):
+        """
+        Check that the table size set by the encoder is lower than the maximum
+        we expect to have.
+        """
+        if self.header_table_size > self.max_allowed_table_size:
+            raise InvalidTableSizeError(
+                "Encoder did not shrink table size to within the max"
+            )
 
     def _update_encoding_context(self, data):
         """

--- a/test/test_hpack.py
+++ b/test/test_hpack.py
@@ -678,6 +678,28 @@ class TestHPACKDecoder(object):
         with pytest.raises(InvalidTableSizeError):
             d.decode(data)
 
+    def test_table_size_last_rejected(self):
+        """
+        If a header table size change comes last in the header block, it is
+        forbidden.
+        """
+        d = Decoder()
+        data = b'\x82\x87\x84A\x8a\x08\x9d\\\x0b\x81p\xdcy\xa6\x99?a'
+
+        with pytest.raises(HPACKDecodingError):
+            d.decode(data)
+
+    def test_table_size_middle_rejected(self):
+        """
+        If a header table size change comes anywhere but first in the header
+        block, it is forbidden.
+        """
+        d = Decoder()
+        data = b'\x82?a\x87\x84A\x8a\x08\x9d\\\x0b\x81p\xdcy\xa6\x99'
+
+        with pytest.raises(HPACKDecodingError):
+            d.decode(data)
+
 
 class TestDictToIterable(object):
     """


### PR DESCRIPTION
Resolves #97.