### PR TITLE
Convert HISTORY.rst from UTF-8 format to ASCII

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,7 +38,7 @@ Release History
 - HPACK now tolerates receiving multiple header table size changes in sequence,
   rather than only one.
 - HPACK now forbids header table size changes anywhere but first in a header
-  block, as required by RFC 7541 § 4.2.
+  block, as required by RFC 7541 S 4.2.
 - Other miscellaneous performance improvements.
 
 2.3.0 (2016-08-04)


### PR DESCRIPTION
UTF-8 formatted file breaks installations on some systems:

Traceback (most recent call last):
  File "setup.py", line 34, in <module>
    long_description=open('README.rst').read() + '\n\n' + open('HISTORY.rst').read(),
  File "/home/peko/autobuild/instance-1/output/target/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1125: ordinal not in range(128)

To fix this error just replace '§' with 'S' meaning 'Section'.