### PR TITLE
Add a ZeroLengthHeaderError raised if header name is 0-length

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ Release History
 
 **API Changes (Backward Compatible)**
 
+- Added a new ``ZeroLengthHeaderNameError`` that indicates that an
+  invalid header has been received. This places the HPACK decoder into
+  a broken state: it must not be used after this exception is thrown.
+
 **Bugfixes**
 
 - Performance improvement of static header search. Use dict search instead

--- a/hpack/__init__.py
+++ b/hpack/__init__.py
@@ -8,13 +8,14 @@ HTTP/2 header encoding for Python.
 from .hpack import Encoder, Decoder
 from .struct import HeaderTuple, NeverIndexedHeaderTuple
 from .exceptions import (
-    HPACKError, HPACKDecodingError, InvalidTableIndex, OversizedHeaderListError
+    HPACKError, HPACKDecodingError, InvalidTableIndex,
+    OversizedHeaderListError, ZeroLengthHeaderNameError,
 )
 
 __all__ = [
     'Encoder', 'Decoder', 'HPACKError', 'HPACKDecodingError',
     'InvalidTableIndex', 'HeaderTuple', 'NeverIndexedHeaderTuple',
-    'OversizedHeaderListError'
+    'OversizedHeaderListError', 'ZeroLengthHeaderNameError',
 ]
 
 __version__ = '3.1.0dev0'

--- a/hpack/exceptions.py
+++ b/hpack/exceptions.py
@@ -47,3 +47,12 @@ class InvalidTableSizeError(HPACKDecodingError):
     .. versionadded:: 3.0.0
     """
     pass
+
+
+class ZeroLengthHeaderNameError(HPACKDecodingError):
+    """
+    An invalid header with a zero length name has been received.
+
+    .. versionadded:: 3.1.0
+    """
+    pass

--- a/test/test_hpack.py
+++ b/test/test_hpack.py
@@ -2,7 +2,7 @@
 from hpack.hpack import Encoder, Decoder, _dict_to_iterable, _to_bytes
 from hpack.exceptions import (
     HPACKDecodingError, InvalidTableIndex, OversizedHeaderListError,
-    InvalidTableSizeError
+    InvalidTableSizeError, ZeroLengthHeaderNameError,
 )
 from hpack.struct import HeaderTuple, NeverIndexedHeaderTuple
 import itertools
@@ -636,6 +636,16 @@ class TestHPACKDecoder(object):
         data = b'\x14\x0c/sample/path'
 
         with pytest.raises(OversizedHeaderListError):
+            d.decode(data)
+
+    def test_zero_length_header(self):
+        """
+        If a header has a name of zero length it is invalid and the HPACK
+        decoder raises a ZeroLengthHeaderNameError.
+        """
+        d = Decoder(max_header_list_size=44)
+        data = b"@\x80\x80"
+        with pytest.raises(ZeroLengthHeaderNameError):
             d.decode(data)
 
     def test_can_decode_multiple_header_table_size_changes(self):


### PR DESCRIPTION
This is to mitigate CVE-2019-9516, 0-Length Headers Leak. It will
allow hpack users, such as hyper-h2, to close connections if this
happens on the basis that the client is likely attempting a DoS
attack.

(I'm happy to help maintain hpack if desired, I would release 3.1.0 with this fix at a minimum).