### PR TITLE
Drop Python 3.3 and add 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ sudo: required
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - pypy
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy, lint
+envlist = py27, py34, py35, py36, py37, pypy, lint
 
 [testenv]
 deps= -r{toxinidir}/test_requirements.txt
@@ -12,7 +12,7 @@ commands=
 commands= py.test hpack {toxinidir}/test/
 
 [testenv:lint]
-basepython=python3.5
+basepython=python3.7
 deps = flake8==3.5.0
 commands = flake8 --max-complexity 10 hpack test utils
 
@@ -23,5 +23,5 @@ deps=
 commands= py.test {toxinidir}/bench/ --benchmark-only --benchmark-group-by=name --benchmark-autosave --benchmark-compare --benchmark-min-rounds=500000
 
 [testenv:create_test_output]
-basepython=python3.5
+basepython=python3.7
 commands = python {toxinidir}/utils/create_test_output.py {posargs}


### PR DESCRIPTION
3.3 was end of life in September 2017. This helps ensure that the CI
passes.