### PR TITLE
fix encoding with generators

### DIFF
--- a/src/hpack/hpack.py
+++ b/src/hpack/hpack.py
@@ -229,7 +229,6 @@ class Encoder:
         # are already in the header table we can represent them using the
         # indexed representation: the same is true if they are in the static
         # table. Otherwise, a literal representation will be used.
-        log.debug("HPACK encoding %s", list(headers))
         header_block = []
 
         # Turn the headers into a list of tuples if possible. This is the
@@ -265,7 +264,12 @@ class Encoder:
         """
         This function takes a header key-value tuple and serializes it.
         """
-        log.debug("Adding %s to the header table", to_add)
+        log.debug(
+            "Adding %s to the header table, sensitive:%s, huffman:%s",
+            to_add,
+            sensitive,
+            huffman
+        )
 
         name, value = to_add
 

--- a/test/test_hpack.py
+++ b/test/test_hpack.py
@@ -338,6 +338,16 @@ class TestHPACKEncoder:
 
         assert len(e.header_table.dynamic_entries) == 1
 
+    def test_headers_generator(self):
+        e = Encoder()
+
+        def headers_generator():
+            return (("k" + str(i), "v" + str(i)) for i in range(3))
+
+        header_set = headers_generator()
+        out = e.encode(header_set)
+        assert Decoder().decode(out) == list(headers_generator())
+
 
 class TestHPACKDecoder:
     # These tests are stolen entirely from the IETF specification examples.


### PR DESCRIPTION
Previously we printed a debug message with the headers to encode. This headers iterable could be a generator, which just debug-printed the type information, but not the expected header values within. See https://github.com/python-hyper/hyper-h2/issues/1219.

As potential fix [a previous commit](https://github.com/python-hyper/hpack/commit/da26ef448423872c8e07f9dbea0e67f603510050) simply converted it to a list - which then rendered the generator empty and unusable. The tests didn't cover this yet.

This commit removes the debug-print altogether, because each added header is already debug-printed in the add() function. We add some additional information to this existing debug print and remove the top-level debug-print in the encode() function.

This commit adds a simple test case for passing a generator as headers into encode().

see https://github.com/python-hyper/hpack/commit/da26ef448423872c8e07f9dbea0e67f603510050#commitcomment-41234380
see https://github.com/python-hyper/hyper-h2/issues/1219#issuecomment-669625785

/cc @dimaqq