### PR TITLE
Fix perfect match missed for headers with empty values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ dev
 **Bugfixes**
 
 - Headers marked as `sensitive` will no longer log their value at DEBUG level. Instead a placeholder value of `SENSITIVE_REDACTED` is logged.
+- Fixed perfect match missed for headers with empty values.
 
 4.1.0 (2025-01-22)
 ------------------

--- a/src/hpack/hpack.py
+++ b/src/hpack/hpack.py
@@ -320,7 +320,7 @@ class Encoder:
         # can use the indexed literal.
         index, name, perfect = match
 
-        if perfect:
+        if perfect is not None:
             # Indexed representation.
             encoded = self._encode_indexed(index)
         else:

--- a/tests/test_hpack.py
+++ b/tests/test_hpack.py
@@ -126,6 +126,18 @@ class TestHPACKEncoder:
         assert e.encode(header_set, huffman=False) == result
         assert list(e.header_table.dynamic_entries) == []
 
+    def test_indexed_header_field_empty_value_string(self):
+        """
+        The header field representation uses an indexed header field, from
+        the static table.
+        """
+        e = Encoder()
+        header_set = {':authority': ''}
+        result = b'\x81'
+
+        assert e.encode(header_set, huffman=False) == result
+        assert list(e.header_table.dynamic_entries) == []
+
     def test_indexed_header_field_from_static_table(self):
         e = Encoder()
         e.header_table_size = 0


### PR DESCRIPTION
`HeaderTable.search()` returns `(index, name, value)` for perfect matches and `(index, name, None)` for partial matches. The encoder distinguishes them with `if perfect:`, but this check fails when `value` is `b""` because empty bytes are falsy in Python.

46 of 61 static table entries have an empty value (`:authority`, `accept-charset`, `accept-language`, `age`, `allow`, `authorization`, `cache-control`, etc.). When encoding a header that perfectly matches one of those entries, the encoder falls through to the indexed-literal branch instead:

```python
>>> from hpack import Encoder
>>> e = Encoder()
>>> e.encode([(b':authority', b'')]).hex()
'4180'   # indexed literal, 2 bytes — also adds to dynamic table
```

Expected: `81` (indexed representation, 1 byte, no dynamic table entry).

The indexed-literal path also calls `self.header_table.add(name, value)`, which adds an unnecessary duplicate of the static entry to the dynamic table, wasting space and evicting useful entries.

This changes `if perfect:` to `if perfect is not None:`.
