### PR TITLE
Document security reporting contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+Please do not report suspected security vulnerabilities in public GitHub
+issues.
+
+To report a vulnerability privately, email the project contacts listed in the
+package metadata:
+
+- Cory Benfield <cory@lukasa.co.uk>
+- Thomas Kriechbaumer <thomas@kriechbaumer.name>
+
+Include the affected hpack version, a description of the issue, reproduction
+steps or proof-of-concept details if available, and any known mitigations.
+
+The Hyper project's broader security guidance is documented at
+https://python-hyper.org/en/latest/security.html.


### PR DESCRIPTION
## Summary
- add a `SECURITY.md` file that directs vulnerability reports away from public issues
- list the public author and maintainer contacts already present in package metadata
- link to the broader Hyper security guidance

Closes #290.

## Validation
- `git diff --check`
- Not run locally